### PR TITLE
fixing broken caching when using craft.twitter.get()

### DIFF
--- a/config.php
+++ b/config.php
@@ -7,6 +7,7 @@ return array(
      * @see http://www.php.net/manual/en/dateinterval.construct.php
      */
     'cacheDuration' => 'PT10M',
+    'cacheDurationSeconds' => 600,
 
     /**
      * Whether request to APIs should be cached or not

--- a/variables/TwitterVariable.php
+++ b/variables/TwitterVariable.php
@@ -26,6 +26,15 @@ class TwitterVariable
      */
 	public function get($uri, $params = array(), $headers = array(), $enableCache = null, $cacheExpire = 0)
 	{
+        if (is_null($enableCache))
+        {
+            $enableCache = craft()->config->get('enableCache', 'twitter');
+        }
+        if (is_null($cacheExpire))
+        {
+            $cacheExpire = craft()->config->get('cacheDurationSeconds', 'twitter');
+        }
+
         try
         {
 		     return craft()->twitter_api->get($uri, $params, $headers, $enableCache, $cacheExpire);


### PR DESCRIPTION
Hiya, I found that your plugin was caching indefinitely when using craft.twitter.get() and suggest the fix here. This could also be the same problem referenced in issue #1 